### PR TITLE
Build with `base-4.18`/GHC 9.6

### DIFF
--- a/lens-sop.cabal
+++ b/lens-sop.cabal
@@ -29,7 +29,7 @@ library
   exposed-modules:     Generics.SOP.Lens
                        Generics.SOP.Lens.Named
                        Generics.SOP.Lens.Computed
-  build-depends:       base          >= 4.6   && < 4.18,
+  build-depends:       base          >= 4.6   && < 4.19,
                        generics-sop  >= 0.2.3 && < 0.6,
                        optics-core   >= 0.4   && < 0.5,
                        transformers  >= 0.3   && < 0.7


### PR DESCRIPTION
Confirmed to build with `allow-newer`.